### PR TITLE
Support transport selection for SCPI connections

### DIFF
--- a/examples/analog_io/analog_io.ino
+++ b/examples/analog_io/analog_io.ino
@@ -29,11 +29,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.aio.reset();
 }

--- a/examples/daisy/daisy.ino
+++ b/examples/daisy/daisy.ino
@@ -33,11 +33,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   bool state;

--- a/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
+++ b/examples/ethernet/Ethernet_acquire_trigger_now/Ethernet_acquire_trigger_now.ino
@@ -148,7 +148,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initStream(scpi_rp::Transport::TCP, &client);
     acquire();
     client.stop();
   } else {

--- a/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
+++ b/examples/ethernet/Ethernet_analog_io/Ethernet_analog_io.ino
@@ -59,7 +59,7 @@ void setup() {
   // if you get a connection, report back via serial:
   if (client.connect(server, 5000)) {
     Serial.println("connected");
-    rp.initStream(&client);
+    rp.initStream(scpi_rp::Transport::TCP, &client);
     isInit = true;
   } else {
     // if you didn't get a connection to the server:

--- a/examples/fast_adc/acquire_external_trigger/acquire_external_trigger.ino
+++ b/examples/fast_adc/acquire_external_trigger/acquire_external_trigger.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   rp.gen.reset();

--- a/examples/fast_adc/acquire_full_buffer_raw/acquire_full_buffer_raw.ino
+++ b/examples/fast_adc/acquire_full_buffer_raw/acquire_full_buffer_raw.ino
@@ -23,11 +23,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.system.log(scpi_rp::CONSOLE);
   if (!rp.acq.control.reset()) {

--- a/examples/fast_adc/acquire_split_trigger_4ch/acquire_split_trigger_4ch.ino
+++ b/examples/fast_adc/acquire_split_trigger_4ch/acquire_split_trigger_4ch.ino
@@ -23,11 +23,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   bool split = true;

--- a/examples/fast_adc/acquire_split_trigger_4ch_level/acquire_split_trigger_4ch_level.ino
+++ b/examples/fast_adc/acquire_split_trigger_4ch_level/acquire_split_trigger_4ch_level.ino
@@ -23,11 +23,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   bool split = true;

--- a/examples/fast_adc/acquire_trigger_from_generator/acquire_trigger_from_generator.ino
+++ b/examples/fast_adc/acquire_trigger_from_generator/acquire_trigger_from_generator.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   rp.gen.reset();

--- a/examples/fast_adc/acquire_trigger_now/acquire_trigger_now.ino
+++ b/examples/fast_adc/acquire_trigger_now/acquire_trigger_now.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   rp.gen.reset();

--- a/examples/fast_adc/dma/acquire_dma_trigger_now/acquire_dma_trigger_now.ino
+++ b/examples/fast_adc/dma/acquire_dma_trigger_now/acquire_dma_trigger_now.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   rp.gen.reset();

--- a/examples/fast_dac/arb_signal/arb_signal.ino
+++ b/examples/fast_dac/arb_signal/arb_signal.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::ARBITRARY);

--- a/examples/fast_dac/burst_switching_wave/burst_switching_wave.ino
+++ b/examples/fast_dac/burst_switching_wave/burst_switching_wave.ino
@@ -25,11 +25,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   scpi_rp::EGENTrigger trig = scpi_rp::GEN_INT;

--- a/examples/fast_dac/burst_with_ext_trigger/burst_with_ext_trigger.ino
+++ b/examples/fast_dac/burst_with_ext_trigger/burst_with_ext_trigger.ino
@@ -25,11 +25,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   rp.dio.reset();

--- a/examples/fast_dac/frequency_switching/frequency_switching.ino
+++ b/examples/fast_dac/frequency_switching/frequency_switching.ino
@@ -27,11 +27,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   if (!rp.gen.reset()) {

--- a/examples/fast_dac/pwm_duty_cycle_30/pwm_duty_cycle_30.ino
+++ b/examples/fast_dac/pwm_duty_cycle_30/pwm_duty_cycle_30.ino
@@ -21,11 +21,11 @@ scpi_rp::SCPIRedPitaya rp;
 void setup() {
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::PWM);

--- a/examples/fast_dac/sine_1ch_continue/sine_1ch_continue.ino
+++ b/examples/fast_dac/sine_1ch_continue/sine_1ch_continue.ino
@@ -21,11 +21,11 @@ scpi_rp::SCPIRedPitaya rp;
 void setup() {
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.gen.reset();
   rp.gen.wave(scpi_rp::GEN_CH_1, scpi_rp::SINE);

--- a/examples/fast_dac/sine_1ch_sweep_mode/sine_1ch_sweep_mode.ino
+++ b/examples/fast_dac/sine_1ch_sweep_mode/sine_1ch_sweep_mode.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   scpi_rp::EGENSweepMode mode = scpi_rp::GEN_SWEEP_LINEAR;

--- a/examples/fast_dac/sine_2ch_continue/sine_2ch_continue.ino
+++ b/examples/fast_dac/sine_2ch_continue/sine_2ch_continue.ino
@@ -24,11 +24,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   if (!rp.gen.reset()) {

--- a/examples/fast_dac/sine_2ch_continue_phase_shift/sine_2ch_continue_phase_shift.ino
+++ b/examples/fast_dac/sine_2ch_continue_phase_shift/sine_2ch_continue_phase_shift.ino
@@ -25,11 +25,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   if (!rp.gen.reset()) {

--- a/examples/leds_and_gpios/gpio/gpio.ino
+++ b/examples/leds_and_gpios/gpio/gpio.ino
@@ -27,11 +27,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.dio.reset();
   rp.dio.dir(scpi_rp::DIO_2_P, scpi_rp::OUT);

--- a/examples/leds_and_gpios/gpio_led_counter/gpio_led_counter.ino
+++ b/examples/leds_and_gpios/gpio_led_counter/gpio_led_counter.ino
@@ -32,11 +32,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.dio.reset();
   rp.dio.dir(scpi_rp::DIO_0_N, scpi_rp::IN);

--- a/examples/leds_and_gpios/led_state/led_state.ino
+++ b/examples/leds_and_gpios/led_state/led_state.ino
@@ -26,11 +26,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.dio.reset();
 }

--- a/examples/leds_and_gpios/leds/leds.ino
+++ b/examples/leds_and_gpios/leds/leds.ino
@@ -23,11 +23,11 @@ uint8_t led_state = 1;
 void setup() {
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
   rp.dio.reset();
 }

--- a/examples/pll/pll.ino
+++ b/examples/pll/pll.ino
@@ -25,11 +25,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   bool state = false;

--- a/examples/system/date_read/date_read.ino
+++ b/examples/system/date_read/date_read.ino
@@ -25,11 +25,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   uint16_t year;

--- a/examples/system/name_read/name_read.ino
+++ b/examples/system/name_read/name_read.ino
@@ -26,11 +26,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 
   char name[BUFF_SIZE];

--- a/examples/system_led/system_led.ino
+++ b/examples/system_led/system_led.ino
@@ -26,11 +26,11 @@ void setup() {
 
 #if defined(ARDUINO_ARCH_AVR)
   uart.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&uart);
+  rp.initStream(scpi_rp::Transport::UART, &uart);
 #elif defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_SAMD) || \
     defined(ARDUINO_ARCH_SAM)
   Serial1.begin(RED_PITAYA_UART_RATE);
-  rp.initStream(&Serial1);
+  rp.initStream(scpi_rp::Transport::UART, &Serial1);
 #endif
 }
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -8,11 +8,13 @@
 
 SCPIRedPitaya	KEYWORD1
 UARTInterface	KEYWORD1
+TCPInterface	KEYWORD1
 UARTProtocol	KEYWORD1
 ESYSLog	KEYWORD1
 SCPISystem	KEYWORD1
 Value KEYWORD1
 BaseIO KEYWORD1
+Transport	KEYWORD1
 
 ###########################################
 # Methods and Functions (KEYWORD2)

--- a/src/SCPI_RP.cpp
+++ b/src/SCPI_RP.cpp
@@ -12,31 +12,52 @@
 #include "SCPI_RP.h"
 
 #include "common/base_io.h"
+#include "tcp/tcp_scpi.h"
 #include "uart/uart_scpi.h"
 
 using namespace scpi_rp;
 
 BaseIO *g_base_io = nullptr;
+bool g_base_io_owned = false;
 
 SCPIRedPitaya::SCPIRedPitaya() {}
 
-SCPIRedPitaya::~SCPIRedPitaya() { delete g_base_io; }
+SCPIRedPitaya::~SCPIRedPitaya() {
+  if (g_base_io_owned) delete g_base_io;
+}
 
-void SCPIRedPitaya::initStream(Stream *serial) {
-  UARTInterface *u = new UARTInterface();
-  u->init(serial);
-  g_base_io = u;
-  system.setInterface(u);
-  dio.setInterface(u);
-  aio.setInterface(u);
-  daisy.setInterface(u);
-  pll.setInterface(u);
-  system_led.setInterface(u);
-  gen.setInterface(u);
-  acq.control.setInterface(u);
-  acq.settings.setInterface(u);
-  acq.data.setInterface(u);
-  acq.trigger.setInterface(u);
-  acq.dma.settings.setInterface(u);
-  acq.dma.data.setInterface(u);
+void SCPIRedPitaya::initStream(BaseIO *io) {
+  g_base_io = io;
+  system.setInterface(io);
+  dio.setInterface(io);
+  aio.setInterface(io);
+  daisy.setInterface(io);
+  pll.setInterface(io);
+  system_led.setInterface(io);
+  gen.setInterface(io);
+  acq.control.setInterface(io);
+  acq.settings.setInterface(io);
+  acq.data.setInterface(io);
+  acq.trigger.setInterface(io);
+  acq.dma.settings.setInterface(io);
+  acq.dma.data.setInterface(io);
+}
+
+void SCPIRedPitaya::initStream(Transport transport, void *ctx) {
+  switch (transport) {
+    case Transport::UART: {
+      UARTInterface *u = new UARTInterface();
+      u->init(static_cast<Stream *>(ctx));
+      g_base_io_owned = true;
+      initStream(static_cast<BaseIO *>(u));
+      break;
+    }
+    case Transport::TCP: {
+      TCPInterface *t = new TCPInterface();
+      t->init(static_cast<Client *>(ctx));
+      g_base_io_owned = true;
+      initStream(static_cast<BaseIO *>(t));
+      break;
+    }
+  }
 }

--- a/src/SCPI_RP.h
+++ b/src/SCPI_RP.h
@@ -12,8 +12,9 @@
 #ifndef SCPI_RP_H
 #define SCPI_RP_H
 
-#include <Stream.h>
 #include <stdint.h>
+
+#include "common/base_io.h"
 
 #include "scpi/scpi_rp_acq_common.h"
 #include "scpi/scpi_rp_aio.h"
@@ -35,10 +36,17 @@ class SCPIRedPitaya {
   SCPIRedPitaya();
   ~SCPIRedPitaya();
 
+  enum class Transport { UART, TCP };
+
   /*!
-   *  @param serial Stream for interface.
+   *  Initialize SCPI interface using an already created IO transport.
    */
-  void initStream(Stream *serial);
+  void initStream(BaseIO *io);
+
+  /*!
+   *  Instantiate and initialize transport by type.
+   */
+  void initStream(Transport transport, void *ctx);
 
   SCPIAio aio;
   SCPIDaisy daisy;


### PR DESCRIPTION
## Summary
- Allow SCPI_RP::initStream to accept a `BaseIO*` or a `Transport` enum
- Instantiate UART or TCP transports based on caller input
- Update all examples to supply the desired transport

## Testing
- `g++ -std=c++11 -I./src -c src/SCPI_RP.cpp` *(fails: Client.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689bbcd5f7f483259e130f77e07083a7