### PR TITLE
Document stream-based transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 ## Description
 
 Arduino library for controlling Red Pitaya boards via SCPI server.
+The library communicates over any Arduino [`Stream`](https://www.arduino.cc/reference/en/language/functions/communication/stream/),
+so it works with transports such as `EthernetClient`, `WiFiClient`, or serial interfaces.
 
 You can get acquainted with Red Pitaya products [here](https://redpitaya.com).
 Information about SCPI server is located [here](https://redpitaya.readthedocs.io/en/latest/appsFeatures/remoteControl/scpi.html).
 
 # Dependencies
  * [Red pitaya boards](https://redpitaya.com/stemlab-125-14/).
+ * An Arduino `Stream` implementation (e.g. Ethernet, WiFi, or Serial) for communication with the SCPI server.
 
 # Contributing
 

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,3 @@ category=Device Control
 url=https://github.com/RedPitaya/SCPI-red-pitaya-arduino
 architectures=*
 includes=SCPI_RP.h
-depends=Ethernet


### PR DESCRIPTION
## Summary
- remove Ethernet-only dependency from library metadata
- explain in README that any Arduino Stream (Ethernet, WiFi, Serial) can be used

## Testing
- `arduino-builder -compile -hardware /usr/share/arduino/hardware -tools /usr/share/arduino-builder -libraries . -fqbn arduino:avr:uno examples/analog_io/analog_io.ino` *(fails: ctags pattern is missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bbf3526348325b6d9655d368dc324