### PR TITLE
Expose Client type and update WiFi example to WiFiS3

### DIFF
--- a/examples/wifi/WiFi_led_toggle/WiFi_led_toggle.ino
+++ b/examples/wifi/WiFi_led_toggle/WiFi_led_toggle.ino
@@ -1,7 +1,7 @@
 /*
   WiFi LED Toggle
 
-  Demonstrates using WiFi to send SCPI commands to a Red Pitaya board.
+  Demonstrates using the WiFiS3 library to send SCPI commands to a Red Pitaya board.
 
   Network setup:
     * Set the SSID and password below to match your WiFi network.
@@ -9,7 +9,7 @@
     * Ensure the Red Pitaya SCPI server is running and reachable on port 5000.
 */
 
-#include <WiFi.h>
+#include <WiFiS3.h>
 #include "SCPI_RP.h"
 #include "tcp/tcp_scpi.h"
 

--- a/src/tcp/tcp_scpi.h
+++ b/src/tcp/tcp_scpi.h
@@ -1,6 +1,7 @@
 #ifndef TCP_SCPI_H
 #define TCP_SCPI_H
 
+#include <Arduino.h>
 #include <Client.h>
 #include <stdint.h>
 


### PR DESCRIPTION
## Summary
- include `<Arduino.h>` before `<Client.h>` so the Client class is defined
- switch WiFi LED toggle example to use the WiFiS3 library

## Testing
- `g++ -std=c++17 -Isrc -I/tmp/ArduinoCore-API/ArduinoCore-API-master/api -I/tmp/stubs -c src/SCPI_RP.cpp`
- `g++ -std=c++17 -Isrc -I/tmp/ArduinoCore-API/ArduinoCore-API-master/api -I/tmp/stubs -c src/tcp/tcp_scpi.cpp`
- `g++ -std=c++17 -x c++ -Isrc -I/tmp/ArduinoCore-API/ArduinoCore-API-master/api -I/tmp/stubs -c examples/wifi/WiFi_led_toggle/WiFi_led_toggle.ino` *(fails: WiFiS3.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bc8820c2883259a3494c0b6d655e0